### PR TITLE
Fixes {:error, {:bad_scheme, "https"}}

### DIFF
--- a/lib/mix/tasks/aoc.ex
+++ b/lib/mix/tasks/aoc.ex
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.Aoc do
 
   defp get_input(session, year, day) do
     start_applications()
-    resp = :httpc.request(:get, {"#{url(year, day)}/input", [cookie(session)]}, [], [])
+    resp = :httpc.request(:get, {'#{url(year, day)}/input', [cookie(session)]}, [], [])
 
     case resp do
       {:ok, {{'HTTP/1.1', 200, 'OK'}, _headers, body}} -> {:ok, body}


### PR DESCRIPTION
I was getting a `{:error, {:bad_scheme, "https"}}` error because `httpc` requires a char list.

Found the solution here: https://elixirforum.com/t/extra-applications-ssl-isnt-started-when-my-library-is-running/19029