### PR TITLE
Use Tz package to align with AOC releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ more information!
     config :iex, inspect: [charlists: :as_lists]
     ```
 
-  - _(Optional)_ Set `time_zone` to `:aoc` if you want the determination of the current
-    puzzle to align with the actual time the AOC website publishes them (midnight US Eastern
-    Standard Time). The default is `:local` which means it switches midnight in your system
-    time. You can also supply a valid time zone string instead:
-
-    ```elixir
-    config :advent_of_code_utils, time_zone: :aoc
-    ```
-
   - If you follow these steps, your `config/config.exs` should look as follows:
 
     ```elixir
@@ -98,7 +89,6 @@ more information!
 
     config :advent_of_code_utils,
       auto_compile?: true,
-      time_zone: :aoc,
       session: "<your session cookie>"
 
     config :iex,
@@ -129,6 +119,28 @@ challenge webpage, which is generally that day's example input.
 Since this method is not 100% reliable, you may you wish to disable this
 behaviour. This can be done by passing the `--no-example` flag to `mix aoc` or
 `mix aoc.get` or by setting `fetch_example` to false in your `config.exs` file.
+
+## Time Zones
+
+By default, this project uses your system time (as determined by
+`NaiveDateTime.local_now/0`), to determine the current "day". Said otherwise,
+if your computer says it is currently the 8th of December, `mix aoc.get`,
+`AOC.IEx.p1/2`, and other functions which reason about time will assume it is
+the 8th day of December. This can be problematic if you live in a time zone
+which does not align well with the publication time of the AOC puzzles
+(midnight US Eastern Standard Time).
+
+This problem can be solved by setting the `time_zone` option of
+`advent_of_code_utils`. When this option is set to `:aoc`, the project will
+determine the current day based on EST, the time zone of the advent of code
+servers. When it is said to `:local` (the default), your system time will be
+used. Alternatively, a valid time zone string can be supplied, in which case
+the project will use determine the current day based on the provided time zone.
+
+```elixir
+# Use the aoc timezone instead of local time
+config :advent_of_code_utils, time_zone: :aoc
+```
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ more information!
     config :iex, inspect: [charlists: :as_lists]
     ```
 
+  - _(Optional)_ Set `time_zone?` to `:aoc` if you want the determination of the current
+    puzzle to align with the actual time the AOC website publishes them (midnight US Eastern
+    Standard Time). The default is `:local` which means it switches midnight in your system
+    time. You can also supply a valid time zone string instead:
+
+    ```elixir
+    config :advent_of_code_utils, time_zone: :aoc
+    ```
+
   - If you follow these steps, your `config/config.exs` should look as follows:
 
     ```elixir
@@ -89,6 +98,7 @@ more information!
 
     config :advent_of_code_utils,
       auto_compile?: true,
+      time_zone: :aoc,
       session: "<your session cookie>"
 
     config :iex,

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ more information!
     config :iex, inspect: [charlists: :as_lists]
     ```
 
-  - _(Optional)_ Set `time_zone?` to `:aoc` if you want the determination of the current
+  - _(Optional)_ Set `time_zone` to `:aoc` if you want the determination of the current
     puzzle to align with the actual time the AOC website publishes them (midnight US Eastern
     Standard Time). The default is `:local` which means it switches midnight in your system
     time. You can also supply a valid time zone string instead:

--- a/lib/aoc/helpers.ex
+++ b/lib/aoc/helpers.ex
@@ -1,8 +1,17 @@
 defmodule AOC.Helpers do
   @moduledoc false
 
-  def day, do: Application.get_env(:advent_of_code_utils, :day, NaiveDateTime.local_now().day)
-  def year, do: Application.get_env(:advent_of_code_utils, :year, NaiveDateTime.local_now().year)
+  def time_zone, do: Application.get_env(:advent_of_code_utils, :time_zone, "EST")
+
+  def now do
+    case DateTime.now(time_zone(), Tz.TimeZoneDatabase) do
+      {:ok, datetime} -> datetime
+      _ -> NaiveDateTime.local_now()
+    end
+  end
+
+  def day, do: Application.get_env(:advent_of_code_utils, :day, now().day)
+  def year, do: Application.get_env(:advent_of_code_utils, :year, now().year)
 
   def module_name(year, day) do
     mod_year = "Y#{year}" |> String.to_atom()

--- a/lib/aoc/helpers.ex
+++ b/lib/aoc/helpers.ex
@@ -1,19 +1,18 @@
 defmodule AOC.Helpers do
   @moduledoc false
-
   @aoc_time_zone "EST"
 
-  def time_zone do
+  defp time_zone do
     case Application.get_env(:advent_of_code_utils, :time_zone, :local) do
-      :local -> nil
+      :local -> :local
       :aoc -> @aoc_time_zone
-      zone -> zone
+      zone when is_binary(zone) -> zone
     end
   end
 
-  def now do
+  defp now do
     case time_zone() do
-      nil -> NaiveDateTime.local_now()
+      :local -> NaiveDateTime.local_now()
       zone -> DateTime.now!(zone, Tz.TimeZoneDatabase)
     end
   end

--- a/lib/aoc/helpers.ex
+++ b/lib/aoc/helpers.ex
@@ -1,12 +1,20 @@
 defmodule AOC.Helpers do
   @moduledoc false
 
-  def time_zone, do: Application.get_env(:advent_of_code_utils, :time_zone, "EST")
+  @aoc_time_zone "EST"
+
+  def time_zone do
+    case Application.get_env(:advent_of_code_utils, :time_zone, :local) do
+      :local -> nil
+      :aoc -> @aoc_time_zone
+      zone -> zone
+    end
+  end
 
   def now do
-    case DateTime.now(time_zone(), Tz.TimeZoneDatabase) do
-      {:ok, datetime} -> datetime
-      _ -> NaiveDateTime.local_now()
+    case time_zone() do
+      nil -> NaiveDateTime.local_now()
+      zone -> DateTime.now!(zone, Tz.TimeZoneDatabase)
     end
   end
 

--- a/lib/aoc/iex.ex
+++ b/lib/aoc/iex.ex
@@ -44,8 +44,9 @@ defmodule AOC.IEx do
   The functions in this module all select a puzzle (or more specifically, its solution module,
   input or example) based on the current time. For instance, the `p1/2` function calls the `p1`
   function of the solution module that corresponds to the current day. The current day (and year)
-  is determined by `NaiveDateTime.local_now/0`. If it is past midnight, or if you wish to solve an
-  older challenge, there are a few options at your disposal:
+  is determined by `NaiveDateTime.local_now/0`, or by `DateTime.now/2` if a time zone was set as
+  described in the README. If it is past midnight, or if you wish to solve an older challenge,
+  there are a few options at your disposal:
 
   - Each function in this module accepts an optional keyword list through which the year and day
     can be specified. For instance, if you wish to run part 1 of of 8 december 1991, you could
@@ -73,7 +74,7 @@ defmodule AOC.IEx do
   1. If year or day is passed as part of the keyword list argument, it is always used.
   2. If `:year` or `:day` is present in the `:advent_of_code_utils` application environment, it is
   used.
-  3. The `year` or `day` returned by `NaiveDateTime.local_now/0` is used.
+  3. The `year` or `day` returned by `NaiveDateTime.local_now/0` or `DateTime.now/2` is used.
 
   ## Automatic recompilation
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule AdventOfCodeUtils.MixProject do
     [
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.29", only: :dev, runtime: false},
-      {:floki, "~> 0.34"}
+      {:floki, "~> 0.34"},
+      {:tz, "~> 0.24.0"}
     ]
   end
 


### PR DESCRIPTION
Operating in local time means that if you aren't operating in US EST, for part of the day `mix aoc` and the p1 and p2 macros refer to the next day's puzzle before it is available.