### PR TITLE
Trim only newlines from stream and from string not at all

### DIFF
--- a/lib/aoc.ex
+++ b/lib/aoc.ex
@@ -229,6 +229,14 @@ defmodule AOC do
   @spec example_stream(pos_integer(), pos_integer()) :: Enumerable.t()
   def example_stream(year, day), do: example_path(year, day) |> path_to_stream()
 
-  defp path_to_string(path), do: path |> File.read!() |> String.trim_trailing()
-  defp path_to_stream(path), do: path |> File.stream!() |> Stream.map(&String.trim/1)
+  defp path_to_string(path) do
+    path
+    |> File.read!
+  end
+
+  defp path_to_stream(path) do
+    path
+    |> File.stream!()
+    |> Stream.map(fn line -> String.trim_trailing(line, "\n") end)
+  end
 end


### PR DESCRIPTION
In Y2022 D5 the left padding was needed to parse the puzzle but there was no way to preserve this info using the library.